### PR TITLE
Patch for MNG-5956

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
+++ b/maven-core/src/main/java/org/apache/maven/project/ProjectSorter.java
@@ -90,6 +90,13 @@ public class ProjectSorter
 
             if ( conflictingProject != null )
             {
+                // skip DuplicateProjectException if they are physically the same pom.xml
+                if ( project.getFile() != null && project.getFile().equals( conflictingProject.getFile() ) )
+                {
+                    continue;
+                }
+
+            {
                 throw new DuplicateProjectException( projectId, conflictingProject.getFile(), project.getFile(),
                                                      "Project '" + projectId + "' is duplicated in the reactor" );
             }


### PR DESCRIPTION
Issue raised https://issues.apache.org/jira/browse/MNG-5956

If you use modules, and that results in the same project/pom being included multiple times then an exception is thrown. But as it's the exact same project/pom it can simple be ignore in my view.

Simple project structure;
./pom.xml
./common/pom.xml
./sub1/pom.xml
./sub2/pom.xml

If sub1 has nested modules but for some reason common should 50% of the time be rebuilded if sub1 i rebuilt then adding <module>../common</module> aids developers.

if sub2 has a similar setup to sub2, then when you build at the root directory an error is produces as both sub1 and sub2 reference common.

This pull request should ignore where the project is an exact match of the same physical pom.